### PR TITLE
Improve report generation resilience

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,6 +49,9 @@ from .src.shared.trace_context import TraceContext, TraceLogFilter
 from .src.utils.logger import logger
 from .src.utils.resilience import GlobalRateLimiter
 
+IMAGE_REPORT_GENERATION_TIMEOUT_SECONDS = 240
+IMAGE_REPORT_SEND_TIMEOUT_SECONDS = 60
+
 
 class GroupDailyAnalysis(Star):
     """群分析插件主类"""
@@ -599,18 +602,46 @@ class GroupDailyAnalysis(Star):
             return None
 
         if output_format == "image":
-            image_url, html_content = await self.report_generator.generate_image_report(
-                analysis_result,
-                group_id,
-                self.html_render,
-                avatar_url_getter=avatar_url_getter,
-                nickname_getter=nickname_getter,
-            )
+            logger.info(f"开始生成图片报告，群: {group_id}")
+            try:
+                image_url, html_content = await asyncio.wait_for(
+                    self.report_generator.generate_image_report(
+                        analysis_result,
+                        group_id,
+                        self.html_render,
+                        avatar_url_getter=avatar_url_getter,
+                        nickname_getter=nickname_getter,
+                    ),
+                    timeout=IMAGE_REPORT_GENERATION_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"图片报告生成超时（{IMAGE_REPORT_GENERATION_TIMEOUT_SECONDS}s），群: {group_id}"
+                )
+                image_url, html_content = None, None
+            except Exception as e:
+                logger.error(f"图片报告生成失败，群: {group_id}: {e}", exc_info=True)
+                image_url, html_content = None, None
 
             if image_url:
                 caption = TraceContext.make_report_caption()
-                sent = await adapter.send_image(group_id, image_url, caption=caption)
+                logger.info(f"图片报告生成成功，准备发送图片，群: {group_id}")
+                try:
+                    sent = await asyncio.wait_for(
+                        adapter.send_image(group_id, image_url, caption=caption),
+                        timeout=IMAGE_REPORT_SEND_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        f"图片报告发送超时（{IMAGE_REPORT_SEND_TIMEOUT_SECONDS}s），群: {group_id}"
+                    )
+                    sent = False
+                except Exception as e:
+                    logger.error(f"图片报告发送异常，群: {group_id}: {e}", exc_info=True)
+                    sent = False
+
                 if sent:
+                    logger.info(f"图片报告发送成功，群: {group_id}")
                     await self._try_upload_image(group_id, image_url, platform_id)
                     return  # 成功发送
 

--- a/src/infrastructure/analysis/llm_analyzer.py
+++ b/src/infrastructure/analysis/llm_analyzer.py
@@ -32,6 +32,7 @@ class LLMAnalyzer(IAnalysisProvider):
     topic_analyzer: TopicAnalyzer
     user_title_analyzer: UserTitleAnalyzer
     golden_quote_analyzer: GoldenQuoteAnalyzer
+    DEFAULT_ANALYSIS_TASK_TIMEOUT_SECONDS = 240
 
     def __init__(self, context, config_manager):
         """
@@ -49,6 +50,36 @@ class LLMAnalyzer(IAnalysisProvider):
         self.user_title_analyzer = UserTitleAnalyzer(context, config_manager)
         self.golden_quote_analyzer = GoldenQuoteAnalyzer(context, config_manager)
         self.chat_quality_analyzer = ChatQualityAnalyzer(context, config_manager)
+
+    def _get_analysis_task_timeout_seconds(self) -> int:
+        """获取单个分析子任务的超时时间，防止一条请求卡死整份报告。"""
+        llm_group_getter = getattr(self.config_manager, "_get_group", None)
+        if callable(llm_group_getter):
+            try:
+                raw_timeout = llm_group_getter("llm").get(
+                    "analysis_task_timeout_seconds",
+                    self.DEFAULT_ANALYSIS_TASK_TIMEOUT_SECONDS,
+                )
+                parsed_timeout = int(raw_timeout)
+                if parsed_timeout > 0:
+                    return parsed_timeout
+            except Exception:
+                pass
+        return self.DEFAULT_ANALYSIS_TASK_TIMEOUT_SECONDS
+
+    async def _run_analysis_task_with_timeout(
+        self, task_name: str, coro, timeout_seconds: int
+    ):
+        """为单个分析子任务添加超时兜底，避免 gather 被永久阻塞。"""
+        try:
+            return await asyncio.wait_for(coro, timeout=timeout_seconds)
+        except asyncio.TimeoutError as exc:
+            logger.warning(
+                f"分析任务 {task_name} 超时，已在 {timeout_seconds}s 后终止并跳过"
+            )
+            raise TimeoutError(
+                f"{task_name} timeout after {timeout_seconds}s"
+            ) from exc
 
     async def analyze_topics(
         self,
@@ -230,33 +261,50 @@ class LLMAnalyzer(IAnalysisProvider):
             # 构建并发任务列表
             tasks = []
             task_names = []
+            task_timeout = self._get_analysis_task_timeout_seconds()
 
             if topic_enabled:
                 tasks.append(
-                    self.topic_analyzer.analyze_topics(messages, umo, session_id)
+                    self._run_analysis_task_with_timeout(
+                        "topic",
+                        self.topic_analyzer.analyze_topics(messages, umo, session_id),
+                        task_timeout,
+                    )
                 )
                 task_names.append("topic")
 
             if user_title_enabled:
                 tasks.append(
-                    self.user_title_analyzer.analyze_user_titles(
-                        messages, user_activity, umo, top_users, session_id
+                    self._run_analysis_task_with_timeout(
+                        "user_title",
+                        self.user_title_analyzer.analyze_user_titles(
+                            messages, user_activity, umo, top_users, session_id
+                        ),
+                        task_timeout,
                     )
                 )
                 task_names.append("user_title")
 
             if golden_quote_enabled:
                 tasks.append(
-                    self.golden_quote_analyzer.analyze_golden_quotes(
-                        messages, umo, session_id
+                    self._run_analysis_task_with_timeout(
+                        "golden_quote",
+                        self.golden_quote_analyzer.analyze_golden_quotes(
+                            messages, umo, session_id
+                        ),
+                        task_timeout,
                     )
                 )
                 task_names.append("golden_quote")
 
             if chat_quality_enabled:
                 tasks.append(
-                    self.chat_quality_analyzer.analyze_quality(
-                        messages, umo, session_id
+                    self._run_analysis_task_with_timeout(
+                        "chat_quality",
+                        self.chat_quality_analyzer.analyze_quality(
+                            messages, umo, session_id
+                        ),
+                        task_timeout,
                     )
                 )
                 task_names.append("chat_quality")
@@ -276,7 +324,10 @@ class LLMAnalyzer(IAnalysisProvider):
             for i, result in enumerate(results):
                 name = task_names[i]
                 if isinstance(result, Exception):
-                    logger.error(f"分析任务 {name} 失败: {result}")
+                    if isinstance(result, (asyncio.TimeoutError, TimeoutError)):
+                        logger.warning(f"分析任务 {name} 超时，已跳过该任务: {result}")
+                    else:
+                        logger.error(f"分析任务 {name} 失败: {result}")
                     continue
 
                 if name == "topic" and isinstance(result, tuple):
@@ -369,6 +420,7 @@ class LLMAnalyzer(IAnalysisProvider):
             # 设置增量模式的最大数量覆盖值
             self.topic_analyzer._incremental_max_count = topics_per_batch
             self.golden_quote_analyzer._incremental_max_count = quotes_per_batch
+            task_timeout = self._get_analysis_task_timeout_seconds()
 
             try:
                 # 构建并发任务列表（仅话题和金句，不包含用户称号）
@@ -377,22 +429,36 @@ class LLMAnalyzer(IAnalysisProvider):
 
                 if topic_enabled:
                     tasks.append(
-                        self.topic_analyzer.analyze_topics(messages, umo, session_id)
+                        self._run_analysis_task_with_timeout(
+                            "topic",
+                            self.topic_analyzer.analyze_topics(
+                                messages, umo, session_id
+                            ),
+                            task_timeout,
+                        )
                     )
                     task_names.append("topic")
 
                 if golden_quote_enabled:
                     tasks.append(
-                        self.golden_quote_analyzer.analyze_golden_quotes(
-                            messages, umo, session_id
+                        self._run_analysis_task_with_timeout(
+                            "golden_quote",
+                            self.golden_quote_analyzer.analyze_golden_quotes(
+                                messages, umo, session_id
+                            ),
+                            task_timeout,
                         )
                     )
                     task_names.append("golden_quote")
 
                 if chat_quality_enabled:
                     tasks.append(
-                        self.chat_quality_analyzer.analyze_quality(
-                            messages, umo, session_id
+                        self._run_analysis_task_with_timeout(
+                            "chat_quality",
+                            self.chat_quality_analyzer.analyze_quality(
+                                messages, umo, session_id
+                            ),
+                            task_timeout,
                         )
                     )
                     task_names.append("chat_quality")
@@ -411,7 +477,10 @@ class LLMAnalyzer(IAnalysisProvider):
                 for i, result in enumerate(results):
                     name = task_names[i]
                     if isinstance(result, Exception):
-                        logger.error(f"增量{name}分析失败: {result}")
+                        if isinstance(result, (asyncio.TimeoutError, TimeoutError)):
+                            logger.warning(f"增量{name}分析超时，已跳过该任务: {result}")
+                        else:
+                            logger.error(f"增量{name}分析失败: {result}")
                         continue
 
                     if name == "topic" and isinstance(result, tuple):

--- a/src/infrastructure/reporting/generators.py
+++ b/src/infrastructure/reporting/generators.py
@@ -28,6 +28,10 @@ from .templates import HTMLTemplates
 
 MAX_CONCURRENT_DOWNLOADS = 10
 AVATAR_CACHE_EXPIRE_TIME = 259200
+DEFAULT_IMAGE_RENDER_STRATEGY_TIMEOUT_SECONDS = 75
+DEFAULT_T2I_PUBLIC_ENDPOINT = "https://t2i.soulter.top/text2img"
+DEFAULT_T2I_OFFICIAL_ENDPOINTS_API = "https://api.soulter.top/astrbot/t2i-endpoints"
+DEFAULT_T2I_ENDPOINTS_CACHE_TTL_SECONDS = 600
 
 DEFAULT_PROFILE_MAPPING = {
     "mbti": {
@@ -110,6 +114,148 @@ class ReportGenerator(IReportGenerator):
         )
         self._avatar_session = None
         self._profile_asset_manifest = self._load_profile_asset_manifest()
+        self._t2i_endpoints_cache: tuple[str, ...] = ()
+        self._t2i_endpoints_cache_expire_at = 0.0
+        self._t2i_endpoint_lock = asyncio.Lock()
+        self._t2i_renderer_cache: dict[str, object] = {}
+
+    @staticmethod
+    def _normalize_t2i_endpoint(endpoint: str | None) -> str:
+        """规范化 T2I 端点地址。"""
+        value = str(endpoint or "").strip().removesuffix("/")
+        if not value:
+            value = DEFAULT_T2I_PUBLIC_ENDPOINT
+        if not value.endswith("text2img"):
+            value = f"{value}/text2img"
+        return value
+
+    async def _get_t2i_render_endpoints(self) -> list[str]:
+        """获取可用的 T2I 渲染端点，并优先使用官方备用端点。"""
+        now = asyncio.get_running_loop().time()
+        if self._t2i_endpoints_cache and now < self._t2i_endpoints_cache_expire_at:
+            return list(self._t2i_endpoints_cache)
+
+        async with self._t2i_endpoint_lock:
+            now = asyncio.get_running_loop().time()
+            if self._t2i_endpoints_cache and now < self._t2i_endpoints_cache_expire_at:
+                return list(self._t2i_endpoints_cache)
+
+            try:
+                from astrbot.core import t2i_base_url
+
+                primary_endpoint = self._normalize_t2i_endpoint(t2i_base_url)
+            except Exception:
+                primary_endpoint = DEFAULT_T2I_PUBLIC_ENDPOINT
+
+            endpoints = [primary_endpoint]
+
+            connector = None
+            try:
+                from astrbot.core.utils.http_ssl import build_tls_connector
+
+                connector = build_tls_connector()
+            except Exception:
+                connector = None
+
+            try:
+                async with aiohttp.ClientSession(
+                    trust_env=True,
+                    connector=connector,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as session:
+                    async with session.get(DEFAULT_T2I_OFFICIAL_ENDPOINTS_API) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            for item in data.get("data", []):
+                                if item.get("active") and item.get("url"):
+                                    endpoints.append(
+                                        self._normalize_t2i_endpoint(item.get("url"))
+                                    )
+                        else:
+                            logger.warning(
+                                f"获取官方 T2I 端点失败，HTTP {resp.status}"
+                            )
+            except Exception as e:
+                logger.warning(f"获取官方 T2I 端点失败: {e}")
+
+            deduped_endpoints: list[str] = []
+            seen: set[str] = set()
+            for endpoint in endpoints:
+                normalized = self._normalize_t2i_endpoint(endpoint)
+                if normalized not in seen:
+                    seen.add(normalized)
+                    deduped_endpoints.append(normalized)
+
+            if primary_endpoint == DEFAULT_T2I_PUBLIC_ENDPOINT and len(deduped_endpoints) > 1:
+                deduped_endpoints = [
+                    endpoint
+                    for endpoint in deduped_endpoints
+                    if endpoint != DEFAULT_T2I_PUBLIC_ENDPOINT
+                ] + [DEFAULT_T2I_PUBLIC_ENDPOINT]
+
+            self._t2i_endpoints_cache = tuple(deduped_endpoints)
+            self._t2i_endpoints_cache_expire_at = (
+                now + DEFAULT_T2I_ENDPOINTS_CACHE_TTL_SECONDS
+            )
+            return list(self._t2i_endpoints_cache)
+
+    def _get_t2i_renderer(self, endpoint: str):
+        """按端点缓存 HtmlRenderer 实例。"""
+        normalized_endpoint = self._normalize_t2i_endpoint(endpoint)
+        renderer = self._t2i_renderer_cache.get(normalized_endpoint)
+        if renderer is None:
+            from astrbot.core.utils.t2i.renderer import HtmlRenderer
+
+            renderer = HtmlRenderer(normalized_endpoint)
+            self._t2i_renderer_cache[normalized_endpoint] = renderer
+        return renderer
+
+    async def _render_html_via_t2i_endpoint(
+        self,
+        endpoint: str,
+        html_content: str,
+        image_options: dict,
+    ):
+        """通过指定 T2I 端点渲染 HTML。"""
+        renderer = self._get_t2i_renderer(endpoint)
+        return await renderer.render_custom_template(
+            html_content,
+            {},
+            return_url=False,
+            options=image_options,
+        )
+
+    @staticmethod
+    def _extract_non_image_response_summary(image_data) -> str | None:
+        """从错误的 HTML 响应里提取概要信息，便于定位上游故障。"""
+        preview_bytes = None
+        if isinstance(image_data, bytes):
+            preview_bytes = image_data[:4096]
+        elif isinstance(image_data, str) and os.path.exists(image_data):
+            try:
+                with open(image_data, "rb") as f:
+                    preview_bytes = f.read(4096)
+            except Exception:
+                preview_bytes = None
+
+        if not preview_bytes:
+            return None
+
+        stripped = preview_bytes.lstrip()
+        if not stripped.startswith(b"<"):
+            return None
+
+        try:
+            preview_text = stripped.decode("utf-8", errors="ignore")
+        except Exception:
+            return None
+
+        title_match = re.search(r"<title>(.*?)</title>", preview_text, re.I | re.S)
+        if title_match:
+            return re.sub(r"\s+", " ", title_match.group(1)).strip()
+
+        compact = re.sub(r"\s+", " ", preview_text)
+        return compact[:160].strip() or None
 
     def _load_profile_asset_manifest(self) -> dict[str, dict]:
         """加载人格资源清单。"""
@@ -369,6 +515,8 @@ class ReportGenerator(IReportGenerator):
             # 使用信号量控制并发进入渲染引擎
             async with self._render_semaphore:
                 logger.debug(f"[T2I] 已进入渲染队列 (群: {group_id})")
+                render_endpoints = await self._get_t2i_render_endpoints()
+                logger.info(f"T2I 渲染候选端点: {render_endpoints}")
 
                 # 定义渲染策略
                 render_strategies = [
@@ -406,68 +554,102 @@ class ReportGenerator(IReportGenerator):
                 ]
 
                 last_exception = None
+                render_timeout_seconds = (
+                    DEFAULT_IMAGE_RENDER_STRATEGY_TIMEOUT_SECONDS
+                )
 
                 for image_options in render_strategies:
-                    try:
-                        # Cleanse options
-                        if image_options.get("type") == "png":
-                            image_options["quality"] = None
+                    if image_options.get("type") == "png":
+                        image_options["quality"] = None
 
-                        logger.info(f"正在尝试渲染策略: {image_options}")
-                        # 改为获取 bytes 数据，避免 OneBot 无法访问内部 URL
-                        image_data = await html_render_func(
-                            html_content,  # 渲染后的HTML内容
-                            {},  # 空数据字典，因为数据已包含在HTML中
-                            False,  # return_url=False，直接获取图片数据
-                            image_options,
-                        )
+                    for endpoint in render_endpoints:
+                        try:
+                            logger.info(
+                                f"正在尝试渲染策略: {image_options} | endpoint={endpoint} | timeout={render_timeout_seconds}s"
+                            )
+                            image_data = await asyncio.wait_for(
+                                self._render_html_via_t2i_endpoint(
+                                    endpoint,
+                                    html_content,
+                                    image_options,
+                                ),
+                                timeout=render_timeout_seconds,
+                            )
 
-                        if image_data:
-                            # 校验是否为合法图片（防止 T2I 返回 500 错误 HTML 字符流）
-                            is_valid = False
-                            actual_data_head = None
+                            if image_data:
+                                is_valid = False
+                                actual_data_head = None
 
-                            if isinstance(image_data, bytes):
-                                actual_data_head = image_data[:10]
-                            elif isinstance(image_data, str) and os.path.exists(
-                                image_data
-                            ):
-                                try:
-                                    with open(image_data, "rb") as f:
-                                        actual_data_head = f.read(10)
-                                except Exception as e:
-                                    logger.warning(f"读取图片临时文件失败: {e}")
-
-                            if actual_data_head:
-                                # 检查 magic numbers (JPEG: FF D8, PNG: 89 50 4E 47)
-                                if actual_data_head.startswith(
-                                    b"\xff\xd8"
-                                ) or actual_data_head.startswith(b"\x89PNG"):
-                                    is_valid = True
-                                else:
-                                    logger.warning(
-                                        f"渲染结果似乎不是有效的图片数据 (头部: {actual_data_head.hex()})"
-                                    )
-
-                            if is_valid:
                                 if isinstance(image_data, bytes):
-                                    b64 = base64.b64encode(image_data).decode("utf-8")
-                                    image_url = f"base64://{b64}"
-                                    logger.info(
-                                        f"图片生成成功 ({image_options}): [Base64 Data {len(image_data)} bytes]"
+                                    actual_data_head = image_data[:10]
+                                elif isinstance(image_data, str) and os.path.exists(
+                                    image_data
+                                ):
+                                    try:
+                                        with open(image_data, "rb") as f:
+                                            actual_data_head = f.read(10)
+                                    except Exception as e:
+                                        logger.warning(f"读取图片临时文件失败: {e}")
+
+                                if actual_data_head:
+                                    if actual_data_head.startswith(
+                                        b"\xff\xd8"
+                                    ) or actual_data_head.startswith(b"\x89PNG"):
+                                        is_valid = True
+                                    else:
+                                        logger.warning(
+                                            f"渲染结果似乎不是有效的图片数据 (头部: {actual_data_head.hex()})"
+                                        )
+
+                                if is_valid:
+                                    if isinstance(image_data, bytes):
+                                        b64 = base64.b64encode(image_data).decode(
+                                            "utf-8"
+                                        )
+                                        image_url = f"base64://{b64}"
+                                        logger.info(
+                                            f"图片生成成功 (endpoint={endpoint}, {image_options}): [Base64 Data {len(image_data)} bytes]"
+                                        )
+                                        return image_url, html_content
+                                    elif isinstance(image_data, str):
+                                        logger.info(
+                                            f"图片生成成功 (endpoint={endpoint}, String): {image_data}"
+                                        )
+                                        return image_data, html_content
+
+                                error_summary = self._extract_non_image_response_summary(
+                                    image_data
+                                )
+                                if error_summary:
+                                    logger.warning(
+                                        f"T2I 端点 {endpoint} 返回了非图片 HTML 响应: {error_summary}"
                                     )
-                                    return image_url, html_content
-                                elif isinstance(image_data, str):
-                                    logger.info(f"图片生成成功 (String): {image_data}")
-                                    return image_data, html_content
+                                    last_exception = RuntimeError(
+                                        f"{endpoint} returned non-image HTML: {error_summary}"
+                                    )
+                                else:
+                                    last_exception = RuntimeError(
+                                        f"{endpoint} returned invalid image data"
+                                    )
 
-                        logger.warning(f"渲染策略 {image_options} 返回了无效或空数据")
+                            logger.warning(
+                                f"渲染策略 {image_options} 在端点 {endpoint} 返回了无效或空数据"
+                            )
 
-                    except Exception as e:
-                        logger.warning(f"渲染策略 {image_options} 失败: {e}")
-                        last_exception = e
-                        logger.warning("尝试下一个策略")
-                        continue
+                        except asyncio.TimeoutError as e:
+                            logger.warning(
+                                f"渲染策略 {image_options} 在端点 {endpoint} 超时（{render_timeout_seconds}s）"
+                            )
+                            last_exception = e
+                            logger.warning("尝试下一个策略")
+                            continue
+                        except Exception as e:
+                            logger.warning(
+                                f"渲染策略 {image_options} 在端点 {endpoint} 失败: {e}"
+                            )
+                            last_exception = e
+                            logger.warning("尝试下一个策略")
+                            continue
 
                 # 如果所有策略都失败
                 logger.error(f"所有渲染策略都失败。最后一个错误: {last_exception}")


### PR DESCRIPTION
## Summary

This PR improves the failure handling around group daily report generation.

In production, I hit a case where report generation looked "randomly broken" across different groups, but there were actually three separate failure modes in the same path:

1. One stuck LLM subtask could block `asyncio.gather()` indefinitely, so the whole report never completed.
2. The default public T2I endpoint (`https://t2i.soulter.top/text2img`) was returning a Cloudflare `502 Bad gateway` HTML page instead of image bytes.
3. Image generation and image sending did not have bounded timeouts, so the request path could hang for a long time before eventually falling back.

This PR adds bounded timeouts, official T2I endpoint fallback, and clearer logging so these failures degrade predictably instead of stalling the entire command.

## Root cause observed

While debugging a live AstrBot deployment on 2026-04-16, the plugin was able to produce reports for some groups but not others.

The main rendering issue was not a template bug. The primary upstream T2I service returned HTML error pages like:

- `<title>soulter.top | 502: Bad gateway</title>`

The plugin previously treated the response as failed/invalid image data and moved on without enough context, and it only targeted a single endpoint by default. At the same time, if one concurrent LLM analyzer call stalled, the whole report pipeline waited forever because `asyncio.gather(..., return_exceptions=True)` still waits for every task to finish.

## What changed

### 1. Add per-analysis task timeouts

`src/infrastructure/analysis/llm_analyzer.py`

- Add a default per-task timeout (`240s`) for each concurrent analysis subtask.
- Wrap topic / user title / golden quote / chat quality analysis calls with `asyncio.wait_for(...)`.
- Log timed out subtasks as warnings and continue assembling the report from the remaining successful subtasks.
- Apply the same timeout behavior to incremental analysis mode.

This keeps one slow or stuck upstream LLM request from blocking the entire report forever.

### 2. Add official T2I endpoint discovery and fallback

`src/infrastructure/reporting/generators.py`

- Fetch and cache official T2I endpoints from `https://api.soulter.top/astrbot/t2i-endpoints`.
- Normalize and deduplicate discovered endpoints.
- When the current primary endpoint is the default public endpoint, prefer trying official backup endpoints first.
- Cache `HtmlRenderer` instances per endpoint.
- Try every render strategy against every available endpoint instead of betting everything on one public node.

This makes rendering resilient when the default public renderer is temporarily unhealthy.

### 3. Detect non-image HTML responses explicitly

`src/infrastructure/reporting/generators.py`

- Inspect returned bytes / temp files for HTML content.
- Extract a concise summary (for example the HTML `<title>`) when the renderer returns an error page instead of an image.
- Log those responses explicitly so operators can distinguish "renderer returned HTML 502" from generic invalid-image failures.

This should make future upstream failures much easier to diagnose from logs.

### 4. Bound image generation and send operations

`main.py`

- Add an overall timeout for image report generation (`240s`).
- Add an overall timeout for image sending (`60s`).
- Add clearer lifecycle logs around generation and send success/failure.

This ensures the command path falls back to text output in a predictable amount of time instead of hanging indefinitely.

## Behavior after this PR

With these changes:

- A single stuck LLM subtask no longer blocks the whole report.
- A dead/unhealthy default T2I endpoint no longer takes down image rendering by itself.
- HTML error pages from the renderer are visible in logs as upstream failures instead of vague invalid-image results.
- The plugin still preserves the existing text fallback behavior when image generation or image sending ultimately fails.

## Verification

Manual verification:

- `python -m py_compile main.py src/infrastructure/analysis/llm_analyzer.py src/infrastructure/reporting/generators.py`
- Deployed the same patch set to a live AstrBot instance and confirmed the plugin resumed generating reports successfully after the renderer fallback logic was added.

If you'd like, I can also split this into multiple smaller PRs, but I kept it together because these failures were all observed in the same end-to-end report generation path.

## Summary by Sourcery

Improve resilience and observability of group daily report generation by adding timeouts and more robust T2I endpoint handling so failures degrade gracefully instead of hanging.

New Features:
- Support configurable per-analysis LLM task timeouts to prevent a single stalled subtask from blocking the whole report.
- Discover and prioritize official T2I endpoints, with per-endpoint HtmlRenderer caching and multi-endpoint rendering attempts for image reports.
- Explicitly detect and summarize non-image HTML responses from T2I services to surface upstream errors in logs.
- Add global time limits for image report generation and image sending to ensure timely fallback to text output.

Enhancements:
- Enhance logging around LLM analysis timeouts, T2I endpoint behavior, and image report lifecycle to aid production diagnosis.