### PR TITLE
fix(platform): 实施适配器精准匹配与多平台调度隔离，修复定时报告重复发送缺陷 (#223)

### DIFF
--- a/src/infrastructure/platform/bot_manager.py
+++ b/src/infrastructure/platform/bot_manager.py
@@ -186,10 +186,8 @@ class BotManager:
                         except Exception:
                             pass
 
-                # 后备检测：如果不支持名称
-                if not platform_name or not PlatformAdapterFactory.is_supported(
-                    str(platform_name)
-                ):
+                # 仅当未从元数据获取到平台名称时，尝试从 bot 实例后备检测
+                if not platform_name and bot_client:
                     detected = self._detect_platform_name(bot_client)
                     if detected:
                         platform_name = detected
@@ -278,63 +276,58 @@ class BotManager:
     # ==================== DDD 集成方法 ====================
 
     def get_adapter(self, platform_id: str | None = None) -> PlatformAdapter | None:
-        """
-        获取指定平台的 PlatformAdapter。
+        """获取指定平台的 PlatformAdapter（精准匹配）。
 
-        支持平台实例 ID 精确匹配、大小写不敏感匹配、协议别名匹配 (如 qq -> aiocqhttp) 与单实例兜底。
+        仅支持：
+        1. 平台实例 ID 精确匹配（如 'aiocqhttp_1'、'nuits'）
+        2. 大小写与首尾空格不敏感匹配
+        3. 标准协议类型名称匹配（如传入 'aiocqhttp'、'telegram' 时匹配对应协议适配器实例）
+
+        若未指定 platform_id 或未精准匹配到任何有效适配器，返回 None。
         """
         # 如果没有任何适配器，尝试全局刷新一次
         if not self._adapters:
             self._refresh_from_stored_platforms()
 
-        if not platform_id or str(platform_id).lower().strip() in (
-            "auto",
-            "default",
-            "all",
-            "none",
-            "",
-        ):
-            if self._adapters:
-                if len(self._adapters) == 1:
-                    return list(self._adapters.values())[0]
-                # 多个适配器且未指定，优先返回第一个就绪的适配器
-                for adp in self._adapters.values():
-                    if adp:
-                        return adp
+        if not platform_id:
+            logger.warning(
+                "[BotManager] get_adapter 调用未提供 platform_id，拒绝模糊匹配"
+            )
+            return None
+
+        clean_id = str(platform_id).strip()
+        if not clean_id or clean_id.lower() in ("auto", "default", "all", "none"):
+            logger.warning(
+                f"[BotManager] get_adapter 传入通配/无效标识 '{platform_id}'，拒绝模糊匹配"
+            )
             return None
 
         # 检查存储的平台实例是否有最新变动
-        if platform_id in self._platforms:
+        if clean_id in self._platforms:
             self._refresh_from_stored_platforms()
 
-        # 1. 精确匹配平台 ID
-        if platform_id in self._adapters:
-            return self._adapters[platform_id]
+        # 1. 精确匹配平台实例 ID
+        if clean_id in self._adapters:
+            return self._adapters[clean_id]
 
-        # 2. 大小写不敏感匹配
-        p_id_lower = str(platform_id).lower().strip()
+        # 2. 大小写与空格不敏感匹配
+        clean_id_lower = clean_id.lower()
         for k, adp in self._adapters.items():
-            if k.lower().strip() == p_id_lower:
+            if k.strip().lower() == clean_id_lower:
                 return adp
 
-        # 3. 通过 PlatformAdapterFactory 注册类型匹配
-        if PlatformAdapterFactory.is_supported(p_id_lower):
-            expected_adapter_cls = PlatformAdapterFactory.get_adapter_class(p_id_lower)
+        # 3. 通过 PlatformAdapterFactory 注册类型匹配（当调用方传入标准协议名如 aiocqhttp/telegram 时）
+        if PlatformAdapterFactory.is_supported(clean_id_lower):
+            expected_adapter_cls = PlatformAdapterFactory.get_adapter_class(
+                clean_id_lower
+            )
             if expected_adapter_cls:
                 for k, adp in self._adapters.items():
                     if isinstance(adp, expected_adapter_cls):
                         logger.info(
-                            f"[BotManager] 平台类型 '{platform_id}' 匹配到已注册适配器 '{k}'"
+                            f"[BotManager] 平台类型 '{platform_id}' 精准匹配到已注册适配器 '{k}'"
                         )
                         return adp
-
-        # 4. 单实例容错兜底：若系统仅有 1 个活跃适配器，自动作为兜底并记录日志
-        if len(self._adapters) == 1:
-            fallback_k, fallback_adp = list(self._adapters.items())[0]
-            logger.info(
-                f"[BotManager] 未找到指定平台 '{platform_id}'，系统当前仅有 1 个活跃适配器 '{fallback_k}'，已自动作为容错兜底使用"
-            )
-            return fallback_adp
 
         logger.warning(
             f"[BotManager] 未找到匹配平台 '{platform_id}' 的适配器。当前已有适配器列表: {list(self._adapters.keys())}"
@@ -461,11 +454,8 @@ class BotManager:
                         if isinstance(dict_name, str):
                             platform_name = dict_name
 
-                # 验证此平台名称是否受支持，如果不支持，尝试从bot实例检测（如果可用）
-                if (
-                    not platform_name
-                    or not PlatformAdapterFactory.is_supported(str(platform_name))
-                ) and bot_client:
+                # 仅当未从元数据获取到平台名称时，尝试从 bot 实例后备检测
+                if not platform_name and bot_client:
                     detected = self._detect_platform_name(bot_client)
                     if detected:
                         platform_name = detected

--- a/src/infrastructure/scheduler/auto_scheduler.py
+++ b/src/infrastructure/scheduler/auto_scheduler.py
@@ -84,46 +84,41 @@ class AutoScheduler:
         self.set_bot_self_ids(bot_qq_ids)
 
     async def get_platform_id_for_group(self, group_id):
-        """根据群ID获取对应的平台ID"""
+        """根据群ID获取对应的平台ID（精准验证）。"""
         try:
-            # 首先检查已注册的bot实例
-            if (
-                hasattr(self.bot_manager, "_bot_instances")
-                and self.bot_manager._bot_instances
-            ):
-                # 如果只有一个实例，直接返回
-                if self.bot_manager.get_platform_count() == 1:
-                    platform_id = self.bot_manager.get_platform_ids()[0]
-                    logger.debug(f"只有一个适配器，使用平台: {platform_id}")
-                    return platform_id
-
-                # 如果有多个实例，尝试通过适配器检查群属于哪个平台
-                logger.info(f"检测到多个适配器，正在验证群 {group_id} 属于哪个平台...")
-                for platform_id in self.bot_manager.get_platform_ids():
-                    try:
-                        adapter = self.bot_manager.get_adapter(platform_id)
-                        if adapter:
-                            # 通过统一接口尝试获取群信息，如果能获取到则说明属于该平台
-                            info = await adapter.get_group_info(str(group_id))
-                            if info:
-                                logger.info(f"✅ 群 {group_id} 属于平台 {platform_id}")
-                                return platform_id
-                            else:
-                                logger.debug(
-                                    f"平台 {platform_id} 无法获取群 {group_id} 信息"
-                                )
-                    except Exception as e:
-                        logger.debug(f"平台 {platform_id} 验证群 {group_id} 失败: {e}")
-                        continue
-
-                # 如果所有适配器都尝试失败，记录错误并返回 None
-                logger.error(
-                    f"❌ 无法确定群 {group_id} 属于哪个平台 (已尝试: {list(self.bot_manager._bot_instances.keys())})"
-                )
+            adapters = (
+                self.bot_manager.get_all_adapters()
+                if hasattr(self.bot_manager, "get_all_adapters")
+                else {}
+            )
+            if not adapters:
+                logger.error("❌ 没有注册的平台适配器")
                 return None
 
-            # 没有任何bot实例，返回None
-            logger.error("❌ 没有注册的bot实例")
+            logger.info(
+                f"正在验证群 {group_id} 属于哪个平台 (已注册适配器: {list(adapters.keys())})..."
+            )
+            for platform_id, adapter in adapters.items():
+                try:
+                    if adapter:
+                        info = await adapter.get_group_info(str(group_id))
+                        if info:
+                            actual_pid = self.bot_manager.get_adapter_platform_id(
+                                adapter
+                            ) or str(platform_id)
+                            logger.info(f"✅ 群 {group_id} 属于平台 {actual_pid}")
+                            return actual_pid
+                        else:
+                            logger.debug(
+                                f"平台 {platform_id} 无法获取群 {group_id} 信息"
+                            )
+                except Exception as e:
+                    logger.debug(f"平台 {platform_id} 验证群 {group_id} 失败: {e}")
+                    continue
+
+            logger.error(
+                f"❌ 无法确定群 {group_id} 属于哪个平台 (已尝试适配器: {list(adapters.keys())})"
+            )
             return None
         except Exception as e:
             logger.error(f"❌ 获取平台ID失败: {e}")
@@ -285,6 +280,7 @@ class AutoScheduler:
         all_groups = await self._get_all_groups()
 
         result = []
+        seen_targets = set()
 
         # 遍历所有平台上的群组
         for platform_id, group_id_orig in all_groups:
@@ -307,7 +303,10 @@ class AutoScheduler:
             if mode_filter and effective_mode != mode_filter:
                 continue
 
-            result.append((group_id, platform_id, effective_mode))
+            target_key = (group_id, platform_id, effective_mode)
+            if target_key not in seen_targets:
+                seen_targets.add(target_key)
+                result.append(target_key)
 
         logger.info(
             f"分层调度解析完成：符合条件的群组共 {len(result)} 个"
@@ -1184,14 +1183,15 @@ class AutoScheduler:
                 continue
 
             try:
-                # 1. 优先从 BotManager 获取已创建的适配器
+                # 1. 优先从 BotManager 获取已创建的适配器（精准匹配）
                 adapter = self.bot_manager.get_adapter(platform_id)
 
-                # 2. 如果没有，尝试临时创建（降级方案）
-                platform_name = None
+                # 2. 如果没有，尝试临时创建（降级方案，仅当受支持时）
                 if not adapter:
                     platform_name = self.bot_manager._detect_platform_name(bot_instance)
-                    if platform_name:
+                    if platform_name and PlatformAdapterFactory.is_supported(
+                        platform_name
+                    ):
                         adapter = PlatformAdapterFactory.create(
                             platform_name,
                             bot_instance,
@@ -1204,6 +1204,9 @@ class AutoScheduler:
                 # 3. 使用适配器获取群列表
                 if adapter:
                     try:
+                        actual_platform_id = self.bot_manager.get_adapter_platform_id(
+                            adapter
+                        ) or str(platform_id)
                         groups = await adapter.get_group_list()
                         groups = [
                             str(group_id).strip()
@@ -1220,18 +1223,18 @@ class AutoScheduler:
                                 p_name = None
 
                         for group_id in groups:
-                            all_groups.add((platform_id, str(group_id)))
+                            all_groups.add((actual_platform_id, str(group_id)))
 
                         logger.info(
-                            f"平台 {platform_id} ({p_name or 'unknown'}) 成功获取 {len(groups)} 个群组"
+                            f"平台 {actual_platform_id} ({p_name or 'unknown'}) 成功获取 {len(groups)} 个群组"
                         )
                         continue
 
                     except Exception as e:
                         logger.warning(f"适配器 {platform_id} 获取群列表失败: {e}")
 
-                # 4. 降级：无法通过适配器获取
-                logger.debug(f"平台 {platform_id} 无法通过适配器获取群列表")
+                # 4. 降级：无法通过适配器获取（跳过该平台）
+                logger.debug(f"平台 {platform_id} 无匹配适配器，跳过获取群列表")
 
             except Exception as e:
                 logger.error(f"平台 {platform_id} 获取群列表异常: {e}")

--- a/tests/test_multi_platform_isolation.py
+++ b/tests/test_multi_platform_isolation.py
@@ -1,0 +1,332 @@
+"""Tests for strict multi-platform adapter matching and scheduler isolation."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.infrastructure.platform.adapters.onebot_adapter import OneBotAdapter
+from src.infrastructure.platform.bot_manager import BotManager
+from src.infrastructure.scheduler.auto_scheduler import AutoScheduler
+
+
+class FakeConfigManager:
+    """Mock ConfigManager for testing scheduler and bot manager."""
+
+    def __init__(self, whitelist: list[str] | None = None) -> None:
+        self.whitelist = whitelist or ["*"]
+
+    def get_filter_bot_messages(self) -> bool:
+        return False
+
+    def get_bot_self_ids(self) -> list[str]:
+        return ["12345678"]
+
+    def is_auto_analysis_enabled(self) -> bool:
+        return True
+
+    def is_scheduled_group_allowed(self, umo: str) -> bool:
+        if "*" in self.whitelist:
+            return True
+        parts = umo.split(":")
+        group_id = parts[-1] if len(parts) >= 3 else umo
+        return umo in self.whitelist or group_id in self.whitelist
+
+    def is_incremental_group_allowed(self, umo: str) -> bool:
+        return False
+
+    def get_incremental_enabled(self) -> bool:
+        return False
+
+    def get_max_concurrent_tasks(self) -> int:
+        return 2
+
+    def get_stagger_seconds(self) -> int:
+        return 0
+
+    def get_llm_max_concurrent(self) -> int:
+        return 1
+
+    def get_analysis_days(self) -> int:
+        return 1
+
+
+class FakePlatformMetadata:
+    def __init__(self, platform_id: str, platform_type: str) -> None:
+        self.id = platform_id
+        self.type = platform_type
+        self.name = platform_type
+
+
+class FakePlatform:
+    def __init__(self, platform_id: str, platform_type: str, client: Any) -> None:
+        self.metadata = FakePlatformMetadata(platform_id, platform_type)
+        self.client = client
+        self.config = {"plugin_set": ["*"]}
+
+    def get_client(self) -> Any:
+        return self.client
+
+
+def test_get_adapter_exact_and_case_insensitive_match():
+    """Verify get_adapter precisely matches registered platform instance IDs."""
+    config_mgr = FakeConfigManager()
+    bot_mgr = BotManager(config_mgr)
+
+    mock_onebot_client = MagicMock()
+    mock_onebot_client.call_action = AsyncMock()
+    bot_mgr.set_bot_instance(
+        mock_onebot_client, platform_id="onebot_main", platform_name="aiocqhttp"
+    )
+
+    # 1. Exact match
+    adapter = bot_mgr.get_adapter("onebot_main")
+    assert adapter is not None
+    assert isinstance(adapter, OneBotAdapter)
+    assert bot_mgr.get_adapter_platform_id(adapter) == "onebot_main"
+
+    # 2. Case-insensitive and trimmed whitespace match
+    adapter_ci = bot_mgr.get_adapter("  ONEBOT_MAIN  ")
+    assert adapter_ci is adapter
+
+
+def test_get_adapter_protocol_type_match():
+    """Verify get_adapter matches registered adapters by supported protocol type name."""
+    config_mgr = FakeConfigManager()
+    bot_mgr = BotManager(config_mgr)
+
+    mock_onebot_client = MagicMock()
+    mock_onebot_client.call_action = AsyncMock()
+    bot_mgr.set_bot_instance(
+        mock_onebot_client, platform_id="custom_qq_bot", platform_name="aiocqhttp"
+    )
+
+    # Matches by standard protocol names
+    adapter_aiocq = bot_mgr.get_adapter("aiocqhttp")
+    assert adapter_aiocq is not None
+    assert isinstance(adapter_aiocq, OneBotAdapter)
+
+    adapter_onebot = bot_mgr.get_adapter("onebot")
+    assert adapter_onebot is adapter_aiocq
+
+
+def test_get_adapter_rejects_unsupported_and_unknown_platforms():
+    """Verify get_adapter strictly returns None for unsupported/unknown platforms without falling back."""
+    config_mgr = FakeConfigManager()
+    bot_mgr = BotManager(config_mgr)
+
+    mock_onebot_client = MagicMock()
+    mock_onebot_client.call_action = AsyncMock()
+    bot_mgr.set_bot_instance(
+        mock_onebot_client, platform_id="onebot_main", platform_name="aiocqhttp"
+    )
+
+    # Single OneBot adapter is active; querying other platforms MUST return None
+    assert bot_mgr.get_adapter("lark-main") is None
+    assert bot_mgr.get_adapter("lark") is None
+    assert bot_mgr.get_adapter("feishu") is None
+    assert bot_mgr.get_adapter("webchat") is None
+    assert bot_mgr.get_adapter("slack") is None
+    assert bot_mgr.get_adapter("non_existent_platform_id") is None
+
+
+def test_get_adapter_rejects_empty_and_wildcard_placeholders():
+    """Verify get_adapter strictly rejects empty or wildcard IDs (precise matching rule)."""
+    config_mgr = FakeConfigManager()
+    bot_mgr = BotManager(config_mgr)
+
+    mock_onebot_client = MagicMock()
+    mock_onebot_client.call_action = AsyncMock()
+    bot_mgr.set_bot_instance(
+        mock_onebot_client, platform_id="onebot_main", platform_name="aiocqhttp"
+    )
+
+    assert bot_mgr.get_adapter(None) is None
+    assert bot_mgr.get_adapter("") is None
+    assert bot_mgr.get_adapter("   ") is None
+    assert bot_mgr.get_adapter("auto") is None
+    assert bot_mgr.get_adapter("default") is None
+    assert bot_mgr.get_adapter("all") is None
+    assert bot_mgr.get_adapter("none") is None
+
+
+@pytest.mark.asyncio
+async def test_auto_scheduler_multi_platform_scanning_isolation():
+    """Verify AutoScheduler scans only supported platforms and prevents duplicate targets (#223)."""
+    config_mgr = FakeConfigManager(whitelist=["10001", "10002", "10003"])
+    bot_mgr = BotManager(config_mgr)
+
+    # 1. Simulate AstrBot with 1 OneBot platform and 1 Lark platform
+    onebot_client = MagicMock()
+    onebot_client.call_action = AsyncMock()
+    lark_client = MagicMock()  # Unsupported client without adapter support
+
+    onebot_platform = FakePlatform("onebot_main", "aiocqhttp", onebot_client)
+    lark_platform = FakePlatform("lark_main", "lark", lark_client)
+
+    fake_context = MagicMock()
+    fake_context.platform_manager = MagicMock()
+    fake_context.platform_manager.get_insts.return_value = [
+        onebot_platform,
+        lark_platform,
+    ]
+
+    bot_mgr.set_context(fake_context)
+    await bot_mgr.auto_discover_bot_instances()
+
+    # Verify adapter creation status
+    assert "onebot_main" in bot_mgr._adapters
+    assert "lark_main" not in bot_mgr._adapters
+
+    # Mock OneBotAdapter get_group_list
+    onebot_adapter = bot_mgr.get_adapter("onebot_main")
+    assert onebot_adapter is not None
+    onebot_adapter.get_group_list = AsyncMock(
+        return_value=["10001", "10002", "10003", "10004"]
+    )
+
+    # 2. Instantiate AutoScheduler and scan groups
+    scheduler = AutoScheduler(
+        config_manager=config_mgr,
+        analysis_service=MagicMock(),
+        bot_manager=bot_mgr,
+    )
+
+    all_groups = await scheduler._get_all_groups()
+
+    # Verify that only OneBot groups are present
+    assert len(all_groups) == 4
+    for pid, gid in all_groups:
+        assert pid == "onebot_main"
+        assert pid != "lark_main"
+
+    # 3. Resolve scheduled targets
+    scheduled_targets = await scheduler._get_scheduled_targets()
+
+    # Only 3 groups match the whitelist (10001, 10002, 10003), each should appear exactly once
+    assert len(scheduled_targets) == 3
+    target_groups = [t[0] for t in scheduled_targets]
+    target_platforms = [t[1] for t in scheduled_targets]
+
+    assert sorted(target_groups) == ["10001", "10002", "10003"]
+    assert set(target_platforms) == {"onebot_main"}
+
+
+@pytest.mark.asyncio
+async def test_get_platform_id_for_group_validates_adapter_presence():
+    """Verify get_platform_id_for_group precisely validates group existence via adapter."""
+    config_mgr = FakeConfigManager()
+    bot_mgr = BotManager(config_mgr)
+
+    onebot_client = MagicMock()
+    onebot_client.call_action = AsyncMock()
+    bot_mgr.set_bot_instance(
+        onebot_client, platform_id="onebot_main", platform_name="aiocqhttp"
+    )
+
+    adapter = bot_mgr.get_adapter("onebot_main")
+    assert adapter is not None
+
+    async def fake_get_group_info(group_id: str):
+        if group_id == "valid_group":
+            info = MagicMock()
+            info.group_name = "Valid Group"
+            return info
+        return None
+
+    adapter.get_group_info = AsyncMock(side_effect=fake_get_group_info)
+
+    scheduler = AutoScheduler(
+        config_manager=config_mgr,
+        analysis_service=MagicMock(),
+        bot_manager=bot_mgr,
+    )
+
+    # Valid group returns the verified platform ID
+    pid = await scheduler.get_platform_id_for_group("valid_group")
+    assert pid == "onebot_main"
+
+    # Non-existent group returns None (no blind return of the 0th platform)
+    unknown_pid = await scheduler.get_platform_id_for_group("non_existent_group")
+    assert unknown_pid is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_supported_platforms_scanning_and_routing():
+    """Verify multiple supported platforms (e.g. 2 OneBot accounts) scan and route independently."""
+    config_mgr = FakeConfigManager(whitelist=["*"])
+    bot_mgr = BotManager(config_mgr)
+
+    bot1_client = MagicMock()
+    bot1_client.call_action = AsyncMock()
+    bot2_client = MagicMock()
+    bot2_client.call_action = AsyncMock()
+
+    bot1_platform = FakePlatform("onebot_account_1", "aiocqhttp", bot1_client)
+    bot2_platform = FakePlatform("onebot_account_2", "aiocqhttp", bot2_client)
+
+    fake_context = MagicMock()
+    fake_context.platform_manager = MagicMock()
+    fake_context.platform_manager.get_insts.return_value = [
+        bot1_platform,
+        bot2_platform,
+    ]
+
+    bot_mgr.set_context(fake_context)
+    await bot_mgr.auto_discover_bot_instances()
+
+    adapter1 = bot_mgr.get_adapter("onebot_account_1")
+    adapter2 = bot_mgr.get_adapter("onebot_account_2")
+
+    assert adapter1 is not None
+    assert adapter2 is not None
+    assert adapter1 is not adapter2
+
+    adapter1.get_group_list = AsyncMock(return_value=["101", "102"])
+    adapter2.get_group_list = AsyncMock(return_value=["201", "202"])
+
+    scheduler = AutoScheduler(
+        config_manager=config_mgr,
+        analysis_service=MagicMock(),
+        bot_manager=bot_mgr,
+    )
+
+    all_groups = await scheduler._get_all_groups()
+    assert len(all_groups) == 4
+    assert ("onebot_account_1", "101") in all_groups
+    assert ("onebot_account_1", "102") in all_groups
+    assert ("onebot_account_2", "201") in all_groups
+    assert ("onebot_account_2", "202") in all_groups
+
+
+@pytest.mark.asyncio
+async def test_analysis_service_rejects_unmatched_platform():
+    """Verify AnalysisApplicationService raises ValueError when an unconfigured platform_id is passed."""
+    from src.application.services.analysis_application_service import (
+        AnalysisApplicationService,
+    )
+
+    config_mgr = FakeConfigManager()
+    bot_mgr = BotManager(config_mgr)
+
+    onebot_client = MagicMock()
+    onebot_client.call_action = AsyncMock()
+    bot_mgr.set_bot_instance(
+        onebot_client, platform_id="onebot_main", platform_name="aiocqhttp"
+    )
+
+    service = AnalysisApplicationService(
+        config_manager=config_mgr,
+        bot_manager=bot_mgr,
+        history_manager=MagicMock(),
+        report_generator=None,
+        llm_analyzer=MagicMock(),
+        statistics_service=MagicMock(),
+        analysis_domain_service=MagicMock(),
+    )
+
+    with pytest.raises(ValueError, match="未找到平台 lark_main 的适配器"):
+        await service.execute_daily_analysis("10001", platform_id="lark_main")
+


### PR DESCRIPTION
- BotManager: 在 `get_adapter()` 中全面实施精准命中，移除跨平台单实例兜底及通配符/缺省回退（"auto"、"default"、空值等），未适配或未匹配平台严格返回 None。
- BotManager: 修正 `auto_discover_bot_instances()` 与 `_refresh_from_stored_platforms()`，避免后备检测覆盖元数据中已知的未受支持平台类型。
- AutoScheduler: `_get_all_groups()` 在扫描群聊资源时跳过无适配器的平台，并使用 `get_adapter_platform_id()` 强绑定适配器的真实平台实例 ID。
- AutoScheduler: `get_platform_id_for_group()` 改为通过有效适配器调用 `get_group_info()` 校验群真实归属，杜绝盲目返回第 0 个实例。
- AutoScheduler: `_get_scheduled_targets()` 增加目标集合去重，确保每个真实平台实例下的每个群在单次调度中仅执行一次。
- Tests: 新增 `tests/test_multi_platform_isolation.py`，覆盖精准匹配、协议名匹配、未适配平台拒绝、通配符拒绝、多平台扫描隔离及调度去重等用例。

Closes #223

## Summary by Sourcery

Enforce precise multi-platform adapter routing and isolate scheduled group processing to prevent cross-platform misrouting and duplicate reports.

Bug Fixes:
- Prevent scheduled reports from being sent more than once per group and platform instance during a single scheduling run.

Enhancements:
- Enforce precise platform adapter resolution and isolate adapter and scheduler operations across multiple platform instances.
- Validate group ownership through the responsible adapter and skip platforms without supported adapters during group discovery.
- Preserve known unsupported platform metadata instead of replacing it with fallback detection.

Tests:
- Add coverage for precise adapter matching, protocol aliases, rejected wildcard and unsupported platforms, multi-platform isolation, group ownership validation, routing, deduplication, and unmatched-platform errors.