### PR TITLE
refactor(stage): 统一收敛流水线阶段与任务状态枚举，消除硬编码魔法字符串

### DIFF
--- a/src/domain/entities/analysis_task.py
+++ b/src/domain/entities/analysis_task.py
@@ -5,19 +5,8 @@
 import time
 import uuid
 from dataclasses import dataclass, field
-from enum import Enum
 
-
-class TaskStatus(Enum):
-    PENDING = "pending"
-    CHECKING_PLATFORM = "checking_platform"
-    FETCHING_MESSAGES = "fetching_messages"
-    ANALYZING = "analyzing"
-    GENERATING_REPORT = "generating_report"
-    SENDING = "sending"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    UNSUPPORTED_PLATFORM = "unsupported_platform"
+from ...shared.constants import AnalysisStage, TaskStatus
 
 
 @dataclass
@@ -29,6 +18,7 @@ class AnalysisTask:
     platform_name: str = ""
     trace_id: str = ""
     status: TaskStatus = TaskStatus.PENDING
+    current_stage: AnalysisStage | str = AnalysisStage.FETCH_MESSAGES
     is_manual: bool = False
     created_at: float = field(default_factory=time.time)
     started_at: float | None = None
@@ -37,18 +27,30 @@ class AnalysisTask:
     error_message: str | None = None
 
     def start(self, can_analyze: bool) -> bool:
-        """启动任务，验证平台能力"""
+        """启动任务，验证平台能力。
+
+        Args:
+            can_analyze: 平台是否支持消息分析能力。
+
+        Returns:
+            bool: 任务启动是否成功。
+        """
         if not can_analyze:
-            self.status = TaskStatus.UNSUPPORTED_PLATFORM
+            self.status = TaskStatus.FAILED
             self.error_message = f"平台 {self.platform_name} 不支持分析"
             return False
-        self.status = TaskStatus.FETCHING_MESSAGES
+        self.status = TaskStatus.RUNNING
+        self.current_stage = AnalysisStage.FETCH_MESSAGES
         self.started_at = time.time()
         return True
 
-    def advance_to(self, status: TaskStatus):
-        """推进到下一个状态"""
-        self.status = status
+    def advance_to(self, stage: AnalysisStage | str) -> None:
+        """推进到下一个流水线阶段。
+
+        Args:
+            stage: 目标阶段。
+        """
+        self.current_stage = stage
 
     def complete(self, result_id: str):
         """标记任务为已完成"""

--- a/src/infrastructure/webui/active_task_manager.py
+++ b/src/infrastructure/webui/active_task_manager.py
@@ -56,10 +56,15 @@ class ActiveTaskManager:
         group_name: str = "",
         platform: str = "",
         trigger_type: str = "manual",
-        current_stage: str = "FETCH_MESSAGES",
+        current_stage: Any = "FETCH_MESSAGES",
         asyncio_task: asyncio.Task[Any] | None = None,
     ) -> None:
         """注册新运行中的任务"""
+        stage_str = (
+            current_stage.value
+            if hasattr(current_stage, "value")
+            else str(current_stage)
+        )
         async with self._lock:
             info = ActiveTaskInfo(
                 task_id=task_id,
@@ -67,17 +72,20 @@ class ActiveTaskManager:
                 group_name=group_name,
                 platform=platform,
                 trigger_type=trigger_type,
-                current_stage=current_stage,
+                current_stage=stage_str,
                 asyncio_task=asyncio_task,
             )
             self._tasks[task_id] = info
         await self._broadcast_event({"event": "task_started", "data": info.to_dict()})
 
-    async def update_stage(self, task_id: str, stage_name: str) -> None:
+    async def update_stage(self, task_id: str, stage_name: Any) -> None:
         """更新当前活跃任务的阶段名称并更新心跳"""
+        stage_str = (
+            stage_name.value if hasattr(stage_name, "value") else str(stage_name)
+        )
         async with self._lock:
             if task_id in self._tasks:
-                self._tasks[task_id].current_stage = stage_name
+                self._tasks[task_id].current_stage = stage_str
                 self._tasks[task_id].last_heartbeat = time.time()
                 info = self._tasks[task_id]
             else:
@@ -90,10 +98,13 @@ class ActiveTaskManager:
 
     update_task_stage = update_stage
 
-    def update_stage_sync(self, task_id: str, stage_name: str) -> None:
+    def update_stage_sync(self, task_id: str, stage_name: Any) -> None:
         """同步更新活跃任务阶段（供 Span 上下文即时调用）"""
+        stage_str = (
+            stage_name.value if hasattr(stage_name, "value") else str(stage_name)
+        )
         if task_id in self._tasks:
-            self._tasks[task_id].current_stage = stage_name
+            self._tasks[task_id].current_stage = stage_str
             self._tasks[task_id].last_heartbeat = time.time()
             info = self._tasks[task_id]
             try:

--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -2,13 +2,14 @@
 共享模块 - 通用工具和常量
 """
 
-from .constants import ContentType, Platform, ReportFormat, TaskStatus
+from .constants import AnalysisStage, ContentType, Platform, ReportFormat, TaskStatus
 from .trace_context import TraceContext
 
 __all__ = [
     "TraceContext",
     "Platform",
     "TaskStatus",
+    "AnalysisStage",
     "ContentType",
     "ReportFormat",
 ]

--- a/src/shared/constants.py
+++ b/src/shared/constants.py
@@ -19,6 +19,26 @@ class Platform(str, Enum):
     SLACK = "slack"
 
 
+class AnalysisStage(str, Enum):
+    """
+    分析与渲染流水线阶段枚举
+
+    定义了全链路追踪、活跃任务打点与 Checkpoint 存储所使用的标准阶段名称。
+    """
+
+    FETCH_MESSAGES = "FETCH_MESSAGES"
+    CLEAN_MESSAGES = "CLEAN_MESSAGES"
+    STATS_ANALYSIS = "STATS_ANALYSIS"
+    LLM_ANALYSIS = "LLM_ANALYSIS"
+    SAVE_SUMMARY = "SAVE_SUMMARY"
+    RENDER_REPORT = "RENDER_REPORT"
+    DISPATCH_REPORT = "DISPATCH_REPORT"
+    CHECKPOINT_RESTORE = "CHECKPOINT_RESTORE"
+    # 漫画生成扩展阶段
+    COMIC_STORYBOARD = "COMIC_STORYBOARD"
+    COMIC_DRAWING = "COMIC_DRAWING"
+
+
 class TaskStatus(str, Enum):
     """
     分析任务执行状态枚举
@@ -31,6 +51,8 @@ class TaskStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+    ABORTED = "aborted"
+    SKIPPED = "skipped"
 
 
 class ContentType(str, Enum):

--- a/src/shared/trace_context.py
+++ b/src/shared/trace_context.py
@@ -118,29 +118,32 @@ class TraceContext:
 
     @contextmanager
     def span(
-        self, stage_name: str, payload: dict[str, Any] | None = None
+        self, stage_name: Any, payload: dict[str, Any] | None = None
     ) -> Generator[dict[str, Any]]:
         """
         创建一个细粒度 Span 上下文，自动记录该步骤耗时与执行状态。
 
         Args:
-            stage_name: 阶段名称，如 'FETCH_MESSAGES', 'LLM_TOPICS', 'RENDER_REPORT'
+            stage_name: 阶段名称，如 AnalysisStage.FETCH_MESSAGES 或字符串
             payload: 随 Span 记录的参数或快照字典
         """
-        self.current_stage = stage_name
+        stage_str = (
+            stage_name.value if hasattr(stage_name, "value") else str(stage_name)
+        )
+        self.current_stage = stage_str
         _active_traces[self.trace_id] = self
         if _global_active_task_manager is not None:
             try:
-                _global_active_task_manager.update_stage_sync(self.trace_id, stage_name)
+                _global_active_task_manager.update_stage_sync(self.trace_id, stage_str)
             except Exception:
                 pass
 
         start_ts = time.time()
-        span_id = f"{self.trace_id}_{stage_name}_{len(self._spans) + 1}"
+        span_id = f"{self.trace_id}_{stage_str}_{len(self._spans) + 1}"
         span_record: dict[str, Any] = {
             "span_id": span_id,
             "trace_id": self.trace_id,
-            "stage_name": stage_name,
+            "stage_name": stage_str,
             "status": "running",
             "started_at": start_ts,
             "duration_ms": None,


### PR DESCRIPTION
## 📝 变更说明 (Change Description)
统一收敛分析流水线各阶段常量与任务状态枚举，消除散落在各模块中的硬编码魔法字符串。

### 关联 Stacked PRs
- **[1/4] [#226](https://github.com/SXP-Simon/astrbot_plugin_qq_group_daily_analysis/pull/226) refactor(stage): 统一收敛流水线阶段与任务状态枚举，消除硬编码魔法字符串** (当前 PR)
- [2/4] [#227](https://github.com/SXP-Simon/astrbot_plugin_qq_group_daily_analysis/pull/227) feat(pipeline): 引入 PipelineContext 异步上下文管理器，实现阶段状态与 Checkpoint 自动化
- [3/4] [#228](https://github.com/SXP-Simon/astrbot_plugin_qq_group_daily_analysis/pull/228) feat(incremental): 对齐增量分析批次与 Checkpoint 存储，提供聚合快照检索能力
- [4/4] [#230](https://github.com/SXP-Simon/astrbot_plugin_qq_group_daily_analysis/pull/230) feat(resume): 增强续跑快照缺失反馈，支持全量降级标记与前端状态透传

---

## 🔍 主要变更 (Key Changes)
1. **统一阶段枚举 (`AnalysisStage`)**:
   - 在 `src/shared/constants.py` 中新增 `AnalysisStage(str, Enum)` 枚举类，标准化 `FETCH_MESSAGES`、`CLEAN_MESSAGES`、`LLM_ANALYSIS`、`RENDER_REPORT` 等核心阶段。
   - 在 `src/shared/__init__.py` 中对外导出 `AnalysisStage`。
2. **收敛任务状态 (`TaskStatus`)**:
   - 将 `TaskStatus(str, Enum)` 收敛至 `src/shared/constants.py`，保持 `PLUGIN_NAME`、`PLUGIN_VERSION` 等基础常量完备。
   - 重构 `src/domain/entities/analysis_task.py`，移除实体内重复的 `TaskStatus` 定义并统一引用共享常量。
3. **向下兼容与类型支持**:
   - `TraceContext.span(stage: AnalysisStage | str)` 支持传入枚举与原生字符串。
   - `ActiveTaskManager.update_task_stage()` 等接口兼容 `AnalysisStage | str` 类型。

---

## 🧪 验证方式 (Verification)
- `uv run pytest tests/` 全量通过 (260/260 passed)。
- `uv run ruff check .` 与 `uv run ruff format --check .` 静态检查无报错。
