### PR TITLE
refactor(stage): 收敛各外围模块遗留的硬编码阶段常量

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ from .src.infrastructure.scheduler.auto_scheduler import AutoScheduler
 from .src.infrastructure.visualization.activity_charts import ActivityVisualizer
 from .src.infrastructure.webui.active_task_manager import ActiveTaskManager
 from .src.infrastructure.webui.plugin_page_bridge import PluginPageWebUIBridge
-from .src.shared.constants import PLUGIN_NAME
+from .src.shared.constants import PLUGIN_NAME, AnalysisStage
 from .src.shared.trace_context import TraceContext
 from .src.utils.logger import logger
 from .src.utils.resilience import GlobalRateLimiter
@@ -714,7 +714,7 @@ class GroupDailyAnalysis(Star):
                     group_name=group_name,
                     platform=platform_id or "",
                     trigger_type="manual",
-                    current_stage="FETCH_MESSAGES",
+                    current_stage=AnalysisStage.FETCH_MESSAGES,
                     asyncio_task=current_task,
                 )
 
@@ -878,7 +878,7 @@ class GroupDailyAnalysis(Star):
                     group_name=group_name or group_id,
                     platform=platform_id or "",
                     trigger_type="comic_manual",
-                    current_stage="FETCH_MESSAGES",
+                    current_stage=AnalysisStage.FETCH_MESSAGES,
                     asyncio_task=current_task,
                 )
 

--- a/src/application/services/comic_application_service.py
+++ b/src/application/services/comic_application_service.py
@@ -11,6 +11,7 @@ from ...infrastructure.drawing.drawing_client import (
     DrawingClient,
     ImageDownloadFailedError,
 )
+from ...shared.constants import AnalysisStage
 from ...shared.trace_context import TraceContext
 from ...utils.logger import logger
 
@@ -69,7 +70,7 @@ class ComicApplicationService:
         trace = TraceContext.current()
 
         # 1. 提取分镜和金句
-        sb_ctx = trace.span("COMIC_STORYBOARD") if trace else nullcontext()
+        sb_ctx = trace.span(AnalysisStage.COMIC_STORYBOARD) if trace else nullcontext()
         with sb_ctx as sb_rec:
             (
                 storyboards,
@@ -145,7 +146,7 @@ class ComicApplicationService:
                     f"[Comic] 无法加载参考图: {Path(reference_image_path).name}"
                 )
 
-        draw_ctx = trace.span("COMIC_DRAWING") if trace else nullcontext()
+        draw_ctx = trace.span(AnalysisStage.COMIC_DRAWING) if trace else nullcontext()
         with draw_ctx as draw_rec:
             # 4. 若配置为外部绘图后端，优先走对应插件出图
             backend = self.config_manager.get_drawing_backend()

--- a/src/infrastructure/logging/plugin_log_buffer.py
+++ b/src/infrastructure/logging/plugin_log_buffer.py
@@ -12,6 +12,8 @@ from collections import deque
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from ...shared.constants import AnalysisStage
+
 
 @dataclass
 class PluginLogEntry:
@@ -91,14 +93,15 @@ class PluginLogBuffer(logging.Handler):
     ]
 
     STAGE_NAMES = {
-        "FETCH_MESSAGES": "拉取聊天记录",
-        "CLEAN_MESSAGES": "消息清洗过滤",
-        "STATS_ANALYSIS": "基础统计分析",
-        "LLM_ANALYSIS": "大模型话题与画像分析",
-        "SAVE_SUMMARY": "历史记录持久化",
-        "RENDER_REPORT": "报告图片渲染与发送",
-        "COMIC_STORYBOARD": "漫画分镜提示词提取",
-        "COMIC_DRAWING": "漫画长图生成与投递",
+        AnalysisStage.FETCH_MESSAGES.value: "拉取聊天记录",
+        AnalysisStage.CLEAN_MESSAGES.value: "消息清洗过滤",
+        AnalysisStage.STATS_ANALYSIS.value: "基础统计分析",
+        AnalysisStage.LLM_ANALYSIS.value: "大模型话题与画像分析",
+        AnalysisStage.SAVE_SUMMARY.value: "历史记录持久化",
+        AnalysisStage.RENDER_REPORT.value: "报告图片渲染与发送",
+        AnalysisStage.DISPATCH_REPORT.value: "群聊消息投递与分发",
+        AnalysisStage.COMIC_STORYBOARD.value: "漫画分镜提示词提取",
+        AnalysisStage.COMIC_DRAWING.value: "漫画长图生成与投递",
         "CRASH_RECOVERY": "异常终止恢复",
     }
 

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+from ...shared.constants import AnalysisStage
 from ...shared.trace_context import TraceContext
 from ...utils.logger import logger
 
@@ -160,7 +161,7 @@ class ReportDispatcher:
         if image_url:
             with (
                 trace_ctx.span(
-                    "DISPATCH_REPORT",
+                    AnalysisStage.DISPATCH_REPORT,
                     {
                         "platform": platform_id or "auto",
                         "group_id": group_id,
@@ -326,7 +327,7 @@ class ReportDispatcher:
         if html_path:
             with (
                 trace_ctx.span(
-                    "DISPATCH_REPORT",
+                    AnalysisStage.DISPATCH_REPORT,
                     {
                         "platform": platform_id or "auto",
                         "group_id": group_id,
@@ -460,7 +461,7 @@ class ReportDispatcher:
 
         with (
             trace_ctx.span(
-                "DISPATCH_REPORT",
+                AnalysisStage.DISPATCH_REPORT,
                 {
                     "platform": platform_id or "auto",
                     "group_id": group_id,

--- a/src/infrastructure/webui/plugin_page_bridge.py
+++ b/src/infrastructure/webui/plugin_page_bridge.py
@@ -65,7 +65,7 @@ else:
             return content
 
 
-from ...shared.constants import PLUGIN_NAME
+from ...shared.constants import PLUGIN_NAME, AnalysisStage
 from ...shared.trace_context import TraceContext
 from ...utils.logger import logger
 from ..persistence.trace_sqlite_store import TraceSQLiteStore
@@ -448,7 +448,7 @@ class PluginPageWebUIBridge:
                 group_name=group_name,
                 platform=platform,
                 trigger_type="web_ui",
-                current_stage="FETCH_MESSAGES",
+                current_stage=AnalysisStage.FETCH_MESSAGES,
                 asyncio_task=asyncio_task,
             )
 
@@ -547,9 +547,9 @@ class PluginPageWebUIBridge:
                 if trace_ctx.status == "running":
                     trace_ctx.finish(status="succeeded")
             else:
-                with trace_ctx.span("FETCH_MESSAGES"):
+                with trace_ctx.span(AnalysisStage.FETCH_MESSAGES):
                     await asyncio.sleep(0.5)
-                with trace_ctx.span("LLM_ANALYSIS"):
+                with trace_ctx.span(AnalysisStage.LLM_ANALYSIS):
                     await asyncio.sleep(1.0)
                 trace_ctx.set_context_metrics(1200, 800)
                 trace_ctx.add_token_usage(1500, 300, "topics")
@@ -608,7 +608,7 @@ class PluginPageWebUIBridge:
                 group_name=group_name,
                 platform=platform,
                 trigger_type="resume",
-                current_stage="LLM_ANALYSIS",
+                current_stage=AnalysisStage.LLM_ANALYSIS,
                 asyncio_task=asyncio_task,
             )
 
@@ -691,7 +691,7 @@ class PluginPageWebUIBridge:
                     if self.report_dispatcher and analysis_result:
                         try:
                             with trace_ctx.span(
-                                "DISPATCH_REPORT",
+                                AnalysisStage.DISPATCH_REPORT,
                                 {
                                     "platform": dispatch_platform_id or "auto",
                                     "group_id": group_id,
@@ -1004,7 +1004,7 @@ class PluginPageWebUIBridge:
                     else (
                         task_info.get("current_stage", "")
                         if task_info
-                        else "FETCH_MESSAGES"
+                        else AnalysisStage.FETCH_MESSAGES.value
                     )
                 )
                 spans = list(active_trace._spans) if active_trace else []


### PR DESCRIPTION
## 📝 变更说明 (Change Description)
全面收敛外围模块中遗留的硬编码阶段字符串（如 `"FETCH_MESSAGES"`、`"LLM_ANALYSIS"`、`"DISPATCH_REPORT"`、`"COMIC_STORYBOARD"`、`"COMIC_DRAWING"` 等），统一引用 `AnalysisStage` 标准枚举，消除魔法字符串。

---

## 🔍 主要变更 (Key Changes)
1. **`main.py`（命令入口层）**:
   - `/群分析` (`analyze_group_daily`) 与 `/群漫画` (`generate_group_comic`) 命令注册活跃任务时，`current_stage` 统一引用 `AnalysisStage.FETCH_MESSAGES`。
2. **`src/application/services/comic_application_service.py`（漫画服务）**:
   - 漫画分镜提取与长图绘制跨度分别使用 `AnalysisStage.COMIC_STORYBOARD` 与 `AnalysisStage.COMIC_DRAWING`。
3. **`src/infrastructure/reporting/dispatcher.py`（报告分发器）**:
   - 图片、HTML 与文本报告分发跨度统一使用 `AnalysisStage.DISPATCH_REPORT`。
4. **`src/infrastructure/webui/plugin_page_bridge.py`（WebUI 桥接层）**:
   - WebUI 手动触发与断点续跑任务注册、Span 跨度记录统一收敛至 `AnalysisStage` 枚举。
5. **`src/infrastructure/logging/plugin_log_buffer.py`（日志缓冲区）**:
   - `STAGE_NAMES` 阶段映射字典 key 统一引用 `AnalysisStage` 成员的 `.value`。

---

## 🧪 验证方式 (Verification)
- `uv run pytest tests/` 全量通过 (260/260 passed)。
- `uv run ruff check .` 与 `uv run ruff format --check .` 静态检查无报错。

## Summary by Sourcery

Standardize analysis stage references across peripheral modules by adopting the shared `AnalysisStage` enum.

Enhancements:
- Replace hard-coded analysis stage strings across command, comic, reporting, WebUI, and logging components with the standard `AnalysisStage` enum.
- Expand stage-name mappings to include report dispatch while keeping user-facing stage labels centralized.

Tests:
- Verify the refactoring with the full test suite and static formatting and lint checks.